### PR TITLE
Deny permission for Claude to access posts dir

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./posts/)",
+      "Read(./posts/**)",
+      "Read(./posts/**/*)"
+    ]
+  }
+}


### PR DESCRIPTION
I do not want Claude to touch the contents of the posts directory, this should prevent that from happening.