### PR TITLE
Remove path exclusions from quarto-publish.yml

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "!.claude/**"
-      - "!.github/**"
-      - "!CLAUDE.md"
-      - "!.gitignore"
 
 name: Render Quarto Website
 


### PR DESCRIPTION
Seemed to prevent all rendering on main so removing until this can be resolved.